### PR TITLE
Fix flattened preview

### DIFF
--- a/Sources/BarcodeScannerController.swift
+++ b/Sources/BarcodeScannerController.swift
@@ -176,7 +176,7 @@ open class BarcodeScannerController: UIViewController {
     super.viewDidLoad()
 
     videoPreviewLayer = AVCaptureVideoPreviewLayer(session: self.captureSession)
-    videoPreviewLayer?.videoGravity = AVLayerVideoGravityResize
+    videoPreviewLayer?.videoGravity = AVLayerVideoGravityResizeAspectFill
 
     view.backgroundColor = UIColor.black
 


### PR DESCRIPTION
When embedded in a container, the scanner preview is not flattened anymore