### PR TITLE
Added localized strings (fr)

### DIFF
--- a/Localization/fr.lproj/Localizable.strings
+++ b/Localization/fr.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+"SCAN_BARCODE_TITLE" = "Scan code-barre";
+"BUTTON_CLOSE" = "Fermer";
+"BUTTON_SETTINGS" = "Réglages";
+"INFO_DESCRIPTION_TEXT" = "Placer le code-barre à scanner dans la fenêtre. La recherche commence automatiquement.";
+"INFO_LOADING_TITLE" = "Recherche ...";
+"NO_PRODUCT_ERROR_TITLE" = "Aucun code-barre n'a pu être reconnu.";
+"ASK_FOR_PERMISSION_TEXT" = "Pour la reconnaissance des codes-barre, vous devez autoriser l'application à utiliser la caméra.";


### PR DESCRIPTION
Added French translation for texts

NB: I wasn't able to check BarcodeScanner in a different language than English, even if I change my iPhone to another language, or if I force another language / region in the scheme, or if I add new languages to my app.
The translations are good, though.