### PR TITLE
Barcode focus view styling choosing

### DIFF
--- a/BarcodeScanner.xcodeproj/project.pbxproj
+++ b/BarcodeScanner.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2DBF9E0E1F169DEF006B5AA8 /* FocusViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBF9E0D1F169DEF006B5AA8 /* FocusViewType.swift */; };
 		D50BE3E91C9FE7A80000A34C /* flashOff@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D50BE3E51C9FE7A80000A34C /* flashOff@3x.png */; };
 		D50BE3EA1C9FE7A80000A34C /* flashOn@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D50BE3E61C9FE7A80000A34C /* flashOn@3x.png */; };
 		D50BE3EB1C9FE7A80000A34C /* info@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D50BE3E71C9FE7A80000A34C /* info@3x.png */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2DBF9E0D1F169DEF006B5AA8 /* FocusViewType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FocusViewType.swift; sourceTree = "<group>"; };
 		D50BE3E51C9FE7A80000A34C /* flashOff@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "flashOff@3x.png"; sourceTree = "<group>"; };
 		D50BE3E61C9FE7A80000A34C /* flashOn@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "flashOn@3x.png"; sourceTree = "<group>"; };
 		D50BE3E71C9FE7A80000A34C /* info@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "info@3x.png"; sourceTree = "<group>"; };
@@ -85,6 +87,7 @@
 				D5FC8AD61D252A12004BED88 /* State.swift */,
 				D5C4E08C1CA0BFB9008D9269 /* InfoView.swift */,
 				D5C4E08D1CA0BFB9008D9269 /* TorchMode.swift */,
+				2DBF9E0D1F169DEF006B5AA8 /* FocusViewType.swift */,
 				D5F1C1C51C9C5113001E17A6 /* Config.swift */,
 				D5F1C1C61C9C5113001E17A6 /* BarcodeScannerController.swift */,
 				D5F1C1D21C9C5809001E17A6 /* HeaderView.swift */,
@@ -178,6 +181,7 @@
 				D5F1C1D31C9C5809001E17A6 /* HeaderView.swift in Sources */,
 				D5F1C1C91C9C5113001E17A6 /* Config.swift in Sources */,
 				D5F1C1CA1C9C5113001E17A6 /* BarcodeScannerController.swift in Sources */,
+				2DBF9E0E1F169DEF006B5AA8 /* FocusViewType.swift in Sources */,
 				D5FC8AD71D252A12004BED88 /* State.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/BarcodeScannerController.swift
+++ b/Sources/BarcodeScannerController.swift
@@ -324,10 +324,10 @@ open class BarcodeScannerController: UIViewController {
       }
     }
 
-    if barCodeFocusViewType == .twoDimentions {
-        center(subview: focusView, inSize: CGSize(width: 218, height: 150))
-    } else {
+    if barCodeFocusViewType == .oneDimention {
         center(subview: focusView, inSize: CGSize(width: 280, height: 80))
+    } else {
+        center(subview: focusView, inSize: CGSize(width: 218, height: 150))
     }
     center(subview: settingsButton, inSize: CGSize(width: 150, height: 50))
 

--- a/Sources/BarcodeScannerController.swift
+++ b/Sources/BarcodeScannerController.swift
@@ -125,6 +125,8 @@ open class BarcodeScannerController: UIViewController {
       })
     }
   }
+    
+  var shouldAnimateFocusView: Bool = true
 
   /// The current torch mode on the capture device.
   var torchMode: TorchMode = .off {
@@ -376,12 +378,14 @@ open class BarcodeScannerController: UIViewController {
   func animateFocusView() {
     focusView.layer.removeAllAnimations()
     focusView.isHidden = false
-
+    
+    if shouldAnimateFocusView {
     UIView.animate(withDuration: 1.0, delay:0,
-      options: [.repeat, .autoreverse, .beginFromCurrentState],
-      animations: {
-        self.center(subview: self.focusView, inSize: CGSize(width: 280, height: 80))
-      }, completion: nil)
+          options: [.repeat, .autoreverse, .beginFromCurrentState],
+          animations: {
+            self.center(subview: self.focusView, inSize: CGSize(width: 280, height: 80))
+          }, completion: nil)
+    }
 
     view.setNeedsLayout()
   }

--- a/Sources/BarcodeScannerController.swift
+++ b/Sources/BarcodeScannerController.swift
@@ -204,7 +204,14 @@ open class BarcodeScannerController: UIViewController {
       name: NSNotification.Name.UIApplicationWillEnterForeground,
       object: nil)
   }
-
+  
+  open override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    setupFrame()
+    
+    headerView.isHidden = !isBeingPresented
+  }
+  
   open override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     animateFocusView()
@@ -302,15 +309,14 @@ open class BarcodeScannerController: UIViewController {
     flashButton.alpha = alpha
     settingsButton.isHidden = status.state != .unauthorized
   }
-
+  
   // MARK: - Layout
-  open override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-
+  
+  func setupFrame() {
     headerView.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 64)
     flashButton.frame = CGRect(x: view.frame.width - 50, y: 73, width: 37, height: 37)
     infoView.frame = infoFrame
-
+    
     if let videoPreviewLayer = videoPreviewLayer {
       videoPreviewLayer.frame = view.layer.bounds
       if let connection = videoPreviewLayer.connection, connection.isVideoOrientationSupported {
@@ -382,6 +388,8 @@ open class BarcodeScannerController: UIViewController {
   func animateFocusView() {
     focusView.layer.removeAllAnimations()
     focusView.isHidden = false
+    
+    setupFrame()
     
     if barCodeFocusViewType == .animated {
         UIView.animate(withDuration: 1.0, delay:0,

--- a/Sources/BarcodeScannerController.swift
+++ b/Sources/BarcodeScannerController.swift
@@ -126,7 +126,7 @@ open class BarcodeScannerController: UIViewController {
     }
   }
     
-  public var shouldAnimateFocusView: Bool = true
+  public var barCodeFocusViewType: FocusViewType = .animated
 
   /// The current torch mode on the capture device.
   var torchMode: TorchMode = .off {
@@ -324,7 +324,11 @@ open class BarcodeScannerController: UIViewController {
       }
     }
 
-    center(subview: focusView, inSize: CGSize(width: 218, height: 150))
+    if barCodeFocusViewType == .twoDimentions {
+        center(subview: focusView, inSize: CGSize(width: 218, height: 150))
+    } else {
+        center(subview: focusView, inSize: CGSize(width: 280, height: 80))
+    }
     center(subview: settingsButton, inSize: CGSize(width: 150, height: 50))
 
     headerView.isHidden = !isBeingPresented
@@ -379,15 +383,14 @@ open class BarcodeScannerController: UIViewController {
     focusView.layer.removeAllAnimations()
     focusView.isHidden = false
     
-    if shouldAnimateFocusView {
-    UIView.animate(withDuration: 1.0, delay:0,
-          options: [.repeat, .autoreverse, .beginFromCurrentState],
-          animations: {
-            self.center(subview: self.focusView, inSize: CGSize(width: 280, height: 80))
-          }, completion: nil)
-    }
-
-    view.setNeedsLayout()
+    if barCodeFocusViewType == .animated {
+        UIView.animate(withDuration: 1.0, delay:0,
+              options: [.repeat, .autoreverse, .beginFromCurrentState],
+              animations: {
+                self.center(subview: self.focusView, inSize: CGSize(width: 280, height: 80))
+              }, completion: nil)
+        }
+        view.setNeedsLayout()
   }
 
   // MARK: - Actions

--- a/Sources/BarcodeScannerController.swift
+++ b/Sources/BarcodeScannerController.swift
@@ -330,7 +330,7 @@ open class BarcodeScannerController: UIViewController {
       }
     }
 
-    if barCodeFocusViewType == .oneDimention {
+    if barCodeFocusViewType == .oneDimension {
         center(subview: focusView, inSize: CGSize(width: 280, height: 80))
     } else {
         center(subview: focusView, inSize: CGSize(width: 218, height: 150))

--- a/Sources/BarcodeScannerController.swift
+++ b/Sources/BarcodeScannerController.swift
@@ -126,7 +126,7 @@ open class BarcodeScannerController: UIViewController {
     }
   }
     
-  var shouldAnimateFocusView: Bool = true
+  public var shouldAnimateFocusView: Bool = true
 
   /// The current torch mode on the capture device.
   var torchMode: TorchMode = .off {

--- a/Sources/FocusViewType.swift
+++ b/Sources/FocusViewType.swift
@@ -1,0 +1,17 @@
+//
+//  FocusViewType.swift
+//  BarcodeScanner
+//
+//  Created by Carl Brusell on 12/07/17.
+//  Copyright © 2017 Hyper Interaktiv AS. All rights reserved.
+//
+
+import UIKit
+
+public enum FocusViewType {
+    
+    case animated
+    case oneDimention
+    case twoDimentions
+
+}

--- a/Sources/FocusViewType.swift
+++ b/Sources/FocusViewType.swift
@@ -1,17 +1,7 @@
-//
-//  FocusViewType.swift
-//  BarcodeScanner
-//
-//  Created by Carl Brusell on 12/07/17.
-//  Copyright © 2017 Hyper Interaktiv AS. All rights reserved.
-//
-
 import UIKit
 
 public enum FocusViewType {
-    
     case animated
     case oneDimension
     case twoDimensions
-
 }

--- a/Sources/FocusViewType.swift
+++ b/Sources/FocusViewType.swift
@@ -11,7 +11,7 @@ import UIKit
 public enum FocusViewType {
     
     case animated
-    case oneDimention
-    case twoDimentions
+    case oneDimension
+    case twoDimensions
 
 }


### PR DESCRIPTION
Here in AMARO, the bar code will be used only for 1D codes, so there's no need for me to have the animation that says it works both 1D and 2D codes.
Made an adaptation for a new BarcodeScannerController attribute called `barCodeFocusViewType` which makes possible to choose between one dimension code, two dimension codes or the animated option that is already implemented.
Please let me know if something is wrong or should be changed. I hope I could help.