### PR TITLE
Bugfix screen orientation + change number of lines of InfoLabel

### DIFF
--- a/Sources/BarcodeScannerController.swift
+++ b/Sources/BarcodeScannerController.swift
@@ -207,7 +207,6 @@ open class BarcodeScannerController: UIViewController {
   
   open override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
-    setupFrame()
     
     headerView.isHidden = !isBeingPresented
   }
@@ -215,6 +214,30 @@ open class BarcodeScannerController: UIViewController {
   open override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     animateFocusView()
+  }
+  
+  open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    super.viewWillTransition(to: size, with: coordinator)
+    
+    coordinator.animate(alongsideTransition: { (context) in
+      self.setupFrame()
+    }) { (context) in
+      
+      self.focusView.layer.removeAllAnimations()
+      
+      UIView.animate(withDuration: 0.3, animations: {
+        if self.barCodeFocusViewType == .oneDimension {
+          self.center(subview: self.focusView, inSize: CGSize(width: 280, height: 80))
+        } else {
+          self.center(subview: self.focusView, inSize: CGSize(width: 218, height: 150))
+        }
+      }, completion: { (finished) in
+        if finished {
+          self.animateFocusView()
+        }
+      })
+      
+    }
   }
 
   /**
@@ -339,7 +362,7 @@ open class BarcodeScannerController: UIViewController {
 
     headerView.isHidden = !isBeingPresented
   }
-
+  
   /**
    Sets a new size and center aligns subview's position.
 

--- a/Sources/BarcodeScannerController.swift
+++ b/Sources/BarcodeScannerController.swift
@@ -218,25 +218,11 @@ open class BarcodeScannerController: UIViewController {
   
   open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
-    
     coordinator.animate(alongsideTransition: { (context) in
       self.setupFrame()
     }) { (context) in
-      
       self.focusView.layer.removeAllAnimations()
-      
-      UIView.animate(withDuration: 0.3, animations: {
-        if self.barCodeFocusViewType == .oneDimension {
-          self.center(subview: self.focusView, inSize: CGSize(width: 280, height: 80))
-        } else {
-          self.center(subview: self.focusView, inSize: CGSize(width: 218, height: 150))
-        }
-      }, completion: { (finished) in
-        if finished {
-          self.animateFocusView()
-        }
-      })
-      
+      self.animateFocusView()
     }
   }
 
@@ -332,14 +318,13 @@ open class BarcodeScannerController: UIViewController {
     flashButton.alpha = alpha
     settingsButton.isHidden = status.state != .unauthorized
   }
-  
+
   // MARK: - Layout
-  
   func setupFrame() {
     headerView.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 64)
     flashButton.frame = CGRect(x: view.frame.width - 50, y: 73, width: 37, height: 37)
     infoView.frame = infoFrame
-    
+
     if let videoPreviewLayer = videoPreviewLayer {
       videoPreviewLayer.frame = view.layer.bounds
       if let connection = videoPreviewLayer.connection, connection.isVideoOrientationSupported {
@@ -362,7 +347,7 @@ open class BarcodeScannerController: UIViewController {
 
     headerView.isHidden = !isBeingPresented
   }
-  
+
   /**
    Sets a new size and center aligns subview's position.
 

--- a/Sources/InfoView.swift
+++ b/Sources/InfoView.swift
@@ -8,7 +8,7 @@ class InfoView: UIVisualEffectView {
   /// Text label.
   lazy var label: UILabel = {
     let label = UILabel()
-    label.numberOfLines = 2
+    label.numberOfLines = 3
 
     return label
   }()


### PR DESCRIPTION
Fix issue #51 and fix problem reported on the [comment](https://github.com/hyperoslo/BarcodeScanner/pull/50#issuecomment-315166305).

I did not implemented the way it was before because this old way was using `viewDidLayoutSubview` but I used the transition so we have more freedom to do a custom animation.

Also, when the rotation is made, we have to stop the animation and start it again because the frame change is not set on the old animation which will cause wrong sizes to happen.

Please let me know if you need anything changed. Thanks!