### PR TITLE
Fixing iPhone X issues, Simulator crash

### DIFF
--- a/Sources/BarcodeScannerController.swift
+++ b/Sources/BarcodeScannerController.swift
@@ -327,7 +327,6 @@ open class BarcodeScannerController: UIViewController {
     let flashButtonSize: CGFloat = 37
     let isLandscape = view.frame.width > view.frame.height
     let isIphoneX = UIDevice().userInterfaceIdiom == .phone && UIScreen.main.nativeBounds.height == 2436
-    var leftSafeAreaInset: CGFloat = 0
     var rightSafeAreaInset: CGFloat = 0
     
     var navbarSize: CGFloat = 0
@@ -339,7 +338,6 @@ open class BarcodeScannerController: UIViewController {
     }
     
     if #available(iOS 11.0, *) {
-        leftSafeAreaInset = view.safeAreaInsets.left
         rightSafeAreaInset = view.safeAreaInsets.right
     }
     

--- a/Sources/BarcodeScannerController.swift
+++ b/Sources/BarcodeScannerController.swift
@@ -265,7 +265,7 @@ open class BarcodeScannerController: UIViewController {
    */
   func setupSession() {
     guard let captureDevice = captureDevice else {
-        return
+      return
     }
     
     do {
@@ -326,19 +326,21 @@ open class BarcodeScannerController: UIViewController {
   func setupFrame() {
     let flashButtonSize: CGFloat = 37
     let isLandscape = view.frame.width > view.frame.height
-    let isIphoneX = UIDevice().userInterfaceIdiom == .phone && UIScreen.main.nativeBounds.height == 2436
+
     var rightSafeAreaInset: CGFloat = 0
+    var topSafeAreaInset: CGFloat = 0
+    if #available(iOS 11.0, *) {
+      rightSafeAreaInset = view.safeAreaInsets.right
+      topSafeAreaInset = view.safeAreaInsets.top
+    }
     
     var navbarSize: CGFloat = 0
     if (isLandscape) {
-        navbarSize = 32
+      navbarSize = 32
     }
     else {
-        navbarSize = isIphoneX ? 88 : 64
-    }
-    
-    if #available(iOS 11.0, *) {
-        rightSafeAreaInset = view.safeAreaInsets.right
+      // On iPhone X devices, extend the size of the top nav bar
+      navbarSize = topSafeAreaInset > 0 ? 88 : 64
     }
     
     headerView.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: navbarSize)

--- a/Sources/HeaderView.swift
+++ b/Sources/HeaderView.swift
@@ -61,16 +61,24 @@ class HeaderView: UIView {
   override func layoutSubviews() {
     super.layoutSubviews()
 
-    let padding: CGFloat = 8
+    var leftSafeAreaPadding: CGFloat = 0
+    var topSafeAreaPadding: CGFloat = 0
+    if #available(iOS 11, *) {
+      leftSafeAreaPadding = safeAreaInsets.left
+      topSafeAreaPadding = safeAreaInsets.top
+    }
+    
+    let leadingPadding: CGFloat = 15 + leftSafeAreaPadding
+    let topPadding: CGFloat = 8 + topSafeAreaPadding
     let labelHeight: CGFloat = 40
-
+    
     button.sizeToFit()
 
-    button.frame.origin = CGPoint(x: 15,
-      y: ((frame.height - button.frame.height) / 2) + padding)
+    button.frame.origin = CGPoint(x: leadingPadding,
+      y: ((frame.height - button.frame.height) / 2) + topPadding)
 
     label.frame = CGRect(
-      x: 0, y: ((frame.height - labelHeight) / 2) + padding,
+      x: 0, y: ((frame.height - labelHeight) / 2) + topPadding,
       width: frame.width, height: labelHeight)
   }
 

--- a/Sources/InfoView.swift
+++ b/Sources/InfoView.swift
@@ -85,6 +85,14 @@ class InfoView: UIVisualEffectView {
    */
   override func layoutSubviews() {
     super.layoutSubviews()
+    
+    var leftSafeAreaPadding: CGFloat = 0
+    var rightSafeAreaPadding: CGFloat = 0
+    
+    if #available(iOS 11.0, *) {
+        leftSafeAreaPadding = safeAreaInsets.left
+        rightSafeAreaPadding = safeAreaInsets.right
+    }
 
     let padding: CGFloat = 10
     let labelHeight: CGFloat = 40
@@ -93,7 +101,7 @@ class InfoView: UIVisualEffectView {
 
     if status.state != .processing && status.state != .notFound {
       imageView.frame = CGRect(
-        x: padding,
+        x: padding + leftSafeAreaPadding,
         y: (frame.height - imageSize.height) / 2,
         width: imageSize.width,
         height: imageSize.height)
@@ -101,7 +109,7 @@ class InfoView: UIVisualEffectView {
       label.frame = CGRect(
         x: imageView.frame.maxX + padding,
         y: 0,
-        width: frame.width - imageView.frame.maxX - 2 * padding,
+        width: frame.width - imageView.frame.maxX - 2 * padding - rightSafeAreaPadding,
         height: frame.height)
     } else {
       imageView.frame = CGRect(


### PR DESCRIPTION
Fixed issues on iPhone X where interactive content was not in the safe area, leading to cropped content. Also fixed issue where the scanner just crashed when running in Simulator, which makes it easier to test and verify layout on multiple devices. Attached screenshots of layout running on iPhone 6 and iPhoneX in both landscape and portrait.

![iphone-portrait](https://user-images.githubusercontent.com/32828869/33653586-609f077c-da22-11e7-951b-0bf1f6de8566.jpg)
![iphone-landscape](https://user-images.githubusercontent.com/32828869/33653587-60b03ccc-da22-11e7-882d-59006ede6996.jpg)
![iphonex-portrait](https://user-images.githubusercontent.com/32828869/33653588-60c12afa-da22-11e7-8239-104daa9004e8.jpg)
![iphonex-landscape](https://user-images.githubusercontent.com/32828869/33653589-60d23bc4-da22-11e7-9463-237789b65225.jpg)
