### PR TITLE
Check for targetEnvironment(simulator) if swift(>=4.1)

### DIFF
--- a/Sources/Helpers/Functions.swift
+++ b/Sources/Helpers/Functions.swift
@@ -37,9 +37,17 @@ func localizedString(_ key: String) -> String {
 
 /// Checks if the app is running in Simulator.
 var isSimulatorRunning: Bool = {
-  #if (arch(i386) || arch(x86_64)) && os(iOS)
-    return true
+  #if swift(>=4.1)
+    #if targetEnvironment(simulator)
+      return true
+    #else
+      return false
+    #endif
   #else
-    return false
+    #if (arch(i386) || arch(x86_64)) && os(iOS)
+      return true
+    #else
+      return false
+    #endif
   #endif
 }()


### PR DESCRIPTION
XCode 9.4/Swift 4.1 gives the following warning, which is fixed with this PR:

> BarcodeScanner/Sources/Helpers/Functions.swift:40:36: Plaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead

