### PR TITLE
update example method calls:

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Use `BarcodeScannerCodeDelegate` when you want to get the captured code back.
 
 ```swift
 extension ViewController: BarcodeScannerCodeDelegate {
-  func barcodeScanner(_ controller: BarcodeScannerViewController, didCaptureCode code: String, type: String) {
+  func scanner(_ controller: BarcodeScannerViewController, didCaptureCode code: String, type: String) {
     print(code)
     controller.reset()
   }
@@ -84,7 +84,7 @@ extension ViewController: BarcodeScannerCodeDelegate {
 Use `BarcodeScannerErrorDelegate` when you want to handle session errors.
 ```swift
 extension ViewController: BarcodeScannerErrorDelegate {
-  func barcodeScanner(_ controller: BarcodeScannerViewController, didReceiveError error: Error) {
+  func scanner(_ controller: BarcodeScannerViewController, didReceiveError error: Error) {
     print(error)
   }
 }
@@ -98,7 +98,7 @@ it was presented initially.
 
 ```swift
 extension ViewController: BarcodeScannerDismissalDelegate {
-  func barcodeScannerDidDismiss(_ controller: BarcodeScannerViewController) {
+  func scannerDidDismiss(_ controller: BarcodeScannerViewController) {
     controller.dismiss(animated: true, completion: nil)
   }
 }
@@ -120,7 +120,7 @@ on the code. When the task is done you have 3 options to proceed:
 1. Dismiss `BarcodeScannerViewController` and show your results.
 
 ```swift
-func barcodeScanner(_ controller: BarcodeScannerViewController, didCaptureCode code: String, type: String) {
+func scanner(_ controller: BarcodeScannerViewController, didCaptureCode code: String, type: String) {
  // Code processing
  controller.dismiss(animated: true, completion: nil)
 }
@@ -134,7 +134,7 @@ when there is no product found with a given barcode in your database):
 </div><br/>
 
 ```swift
-func barcodeScanner(_ controller: BarcodeScannerViewController, didCaptureCode code: String, type: String) {
+func scanner(_ controller: BarcodeScannerViewController, didCaptureCode code: String, type: String) {
  // Code processing
  controller.resetWithError(message: "Error message")
  // If message is not provided the default message will be used instead.
@@ -144,7 +144,7 @@ func barcodeScanner(_ controller: BarcodeScannerViewController, didCaptureCode c
 3. Reset the controller to the scanning mode (with or without animation):
 
  ```swift
- func barcodeScanner(_ controller: BarcodeScannerViewController, didCaptureCode code: String, type: String) {
+ func scanner(_ controller: BarcodeScannerViewController, didCaptureCode code: String, type: String) {
    // Code processing
    controller.reset(animated: true)
  }


### PR DESCRIPTION
In the given examples the function names  of the protocols still begin with "barcode". Though now they only are scanner(...) instead of barcodeScanner(...). I've updated this because it led to confusion for me.