### PR TITLE
Add initialCameraPosition feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ let viewController = BarcodeScannerViewController()
 viewController.cameraViewController.barCodeFocusViewType = .animated
 // Show camera position button
 viewController.cameraViewController.showsCameraButton = true
+// Set the initial camera position
+viewController.cameraViewController.initialCameraPosition = .front // Default is .back
 // Set settings button text
 let title = NSAttributedString(
   string: "Settings",

--- a/Sources/Controllers/CameraViewController.swift
+++ b/Sources/Controllers/CameraViewController.swift
@@ -19,6 +19,7 @@ public final class CameraViewController: UIViewController {
 
   /// Focus view type.
   public var barCodeFocusViewType: FocusViewType = .animated
+  public var initialCameraPosition: AVCaptureDevice.Position = .back
   public var showsCameraButton: Bool = false {
     didSet {
       cameraButton.isHidden = showsCameraButton
@@ -213,7 +214,7 @@ public final class CameraViewController: UIViewController {
       }
 
       if error == nil {
-        strongSelf.setupSessionInput(for: .back)
+        strongSelf.setupSessionInput(for: strongSelf.initialCameraPosition)
         strongSelf.setupSessionOutput()
         strongSelf.delegate?.cameraViewControllerDidSetupCaptureSession(strongSelf)
       } else {


### PR DESCRIPTION
I added a new property `initialCameraPosition` to the `CameraViewController` class to allow for setting the camera position upon presentation of the `BarcodeScannerViewController`.

This should address #129 *(which I has also requested.)*