### PR TITLE
Fix invalid resource SPM warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "BarcodeScanner",
-            path: "Sources",
-            resources: [.copy("Images/cameraRotate@3x.png")]),
+            path: "Sources"
+        ),
     ]
 )


### PR DESCRIPTION
Simply remove the `resources: [.copy("Images/cameraRotate@3x.png")])` part of the SPM resources, as this file is already handled as part of the .xcassets

Fixes https://github.com/hyperoslo/BarcodeScanner/issues/203