### PR TITLE
Increase of iOS Version in order to be able to use it in macCatalyst

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "BarcodeScanner",
     defaultLocalization: "en",
-    platforms: [.iOS(.v10)],
+    platforms: [.iOS(.v14)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,7 @@ import PackageDescription
 let package = Package(
     name: "BarcodeScanner",
     defaultLocalization: "en",
-    platforms: [.iOS(.v10),
-               .macOS(.v11),
-               .macCatalyst(.v15)],
+    platforms: [.iOS(.v11)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     name: "BarcodeScanner",
     defaultLocalization: "en",
     platforms: [.iOS(.v10),
-               .macOS(.v11)],
+               .macOS(.v11),
+               .macCatalyst(v14)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "BarcodeScanner",
     defaultLocalization: "en",
     platforms: [.iOS(.v10),
-               .mac(.v11)],
+               .macOS(.v11)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "BarcodeScanner",
     defaultLocalization: "en",
-    platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v10),
+               .mac(.v11)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "BarcodeScanner",
     defaultLocalization: "en",
-    platforms: [.iOS(.v11)],
+    platforms: [.iOS(.v14)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [.iOS(.v10),
                .macOS(.v11),
-               .macCatalyst(.v14)],
+               .macCatalyst(.v15)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [.iOS(.v10),
                .macOS(.v11),
-               .macCatalyst(v14)],
+               .macCatalyst(.v14)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
A lot of the AV Functions used in this framework can be used in Mac catalyst v14. The corresponding iOS Version should be the minimum in order to use the Scanner on MacCatalyst.