### PR TITLE
Fixed issue: "[AVCaptureSession startRunning] should be called from background thread"

### DIFF
--- a/Sources/Controllers/CameraViewController.swift
+++ b/Sources/Controllers/CameraViewController.swift
@@ -134,7 +134,9 @@ public final class CameraViewController: UIViewController {
     }
 
     torchMode = .off
-    captureSession.startRunning()
+    DispatchQueue.global(qos: .background).async {
+      self.captureSession.startRunning()
+    }
     focusView.isHidden = false
     flashButton.isHidden = captureDevice?.position == .front
     cameraButton.isHidden = !showsCameraButton


### PR DESCRIPTION
### Description
This Pull Request addresses an issue where the [AVCaptureSession startRunning] method is called from the main thread, leading to potential UI unresponsiveness. To resolve this issue, the method should be called from a background thread.

### Changes Made
Moved the [AVCaptureSession startRunning] method call to a background thread to ensure it is not executed on the main thread.
Used Grand Central Dispatch (GCD) to asynchronously call the method on a background queue.
<img width="731" alt="스크린샷 2023-06-08 16 49 59" src="https://github.com/hyperoslo/BarcodeScanner/assets/80062632/92ba6de4-e547-4109-a0d9-800a7eb22a44">

### Testing
Tested the updated code on various devices and scenarios to verify that the UI remains responsive during the execution of [AVCaptureSession startRunning].
- Related Issue: #218

Please review and consider merging this Pull Request. Thank you! :)